### PR TITLE
Add client_prev_sel command

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -131,6 +131,26 @@ client_get_prev(void)
      return c;
 }
 
+/** Get the previously selected client
+ *\return The previously selected client or NULL
+ */
+static Client*
+client_get_prev_sel(void)
+{
+     Client *prevsel = NULL;
+
+     screen_get_sel();
+
+     if(!sel || ishide(sel, selscreen))
+          return NULL;
+
+     prevsel = tags[selscreen][sel->tag].prevsel;
+     if (!prevsel || ishide(prevsel, selscreen))
+          return NULL;
+
+     return prevsel;
+}
+
 /** Get client left/right/top/bottom of selected client
   *\param pos Position (Left/Right/Top/Bottom
   *\return Client found
@@ -202,6 +222,24 @@ uicb_client_next(uicb_t cmd)
      (void)cmd;
 
      if((c = client_get_next()))
+     {
+          client_focus(c);
+          client_raise(c);
+     }
+
+     return;
+}
+
+/** Switch to the previously selected client
+ * \param cmd uicb_t type unused
+ */
+void
+uicb_client_prev_sel(uicb_t cmd)
+{
+     Client *c;
+     (void)cmd;
+
+     if((c = client_get_prev_sel()))
      {
           client_focus(c);
           client_raise(c);
@@ -370,6 +408,10 @@ client_focus(Client *c)
           frame_update(sel);
 
           mouse_grabbuttons(sel, !conf.focus_pclick);
+
+          /* Only record previously selected client in case we are not switching tags */
+          if (c && c->tag == sel->tag)
+               tags[sel->screen][sel->tag].prevsel = sel;
      }
 
      if((sel = c))

--- a/src/config.c
+++ b/src/config.c
@@ -37,6 +37,7 @@ const func_name_list_t func_list[] =
      {"spawn",                    uicb_spawn },
      {"client_kill",              uicb_client_kill },
      {"client_prev",              uicb_client_prev },
+     {"client_prev_sel",          uicb_client_prev_sel },
      {"client_next",              uicb_client_next },
      {"client_swap_next",         uicb_client_swap_next },
      {"client_swap_prev",         uicb_client_swap_prev },
@@ -522,7 +523,7 @@ conf_tag_section(void)
      /* If there is no tag in the conf or more than
       * MAXTAG (36) print an error and create only one.
       */
-     Tag default_tag = { fetch_opt_first(def_tag, "new tag", "name").str, NULL, 0, 1,
+     Tag default_tag = { fetch_opt_first(def_tag, "new tag", "name").str, NULL, 0, NULL, 1,
                          fetch_opt_first(def_tag, "0.6", "mwfact").fnum,
                          fetch_opt_first(def_tag, "1", "nmaster").num,
                          False, fetch_opt_first(def_tag, "False", "resizehint").bool,

--- a/src/structs.h
+++ b/src/structs.h
@@ -279,6 +279,7 @@ typedef struct
      char *name;
      char **clients;
      int nclients;
+     Client *prevsel;
      int layers;
      float mwfact;
      int nmaster;

--- a/src/tag.c
+++ b/src/tag.c
@@ -372,7 +372,7 @@ uicb_tag_stay_last(uicb_t cmd)
      {
           int i;
           remove_old_last_tag(selscreen);
-          
+
           for(i = seltag[selscreen]; i <= conf.ntag[selscreen]; i++)
           {
                tag_swap(selscreen, seltag[selscreen], seltag[selscreen] + 1);
@@ -601,7 +601,7 @@ tag_new(int s, char *name)
          displayedName = xstrdup(name);
 
 
-     Tag t = { displayedName, NULL, 0, 0,
+     Tag t = { displayedName, NULL, 0, NULL, 0,
                conf.default_tag.mwfact, conf.default_tag.nmaster,
                False, conf.default_tag.resizehint, False, False,
                conf.default_tag.barpos, conf.default_tag.barpos, conf.default_tag.layout,
@@ -760,7 +760,7 @@ uicb_tag_toggle_expose(uicb_t cmd)
                return;
           }
      }
-     
+
      tag_new(selscreen, conf.tag_expose_name);
 
      for(i = 0; i < conf.nlayout; ++i)
@@ -775,7 +775,7 @@ uicb_tag_toggle_expose(uicb_t cmd)
      {
           tags[selscreen][conf.ntag[selscreen]].tagad ^= TagFlag(i);
      }
-     
+
      tags[selscreen][conf.ntag[selscreen]].request_update = True;
      arrange(selscreen, True);
 

--- a/src/viwmfs.c
+++ b/src/viwmfs.c
@@ -53,6 +53,7 @@ static vicmd_to_uicb vicmd[] =
      {"ctp",     "tag_transfert_prev"},
      {"cn",      "client_next"},
      {"cp",      "client_prev"},
+     {"cps",     "client_prev_sel"},
      {"csn",     "client_swap_next"},
      {"csp",     "client_swap_prev"},
      {"mwf",     "set_mwfact"},

--- a/src/wmfs.h
+++ b/src/wmfs.h
@@ -185,6 +185,7 @@ void client_urgent(Client *c, Bool u);
 void uicb_client_raise(uicb_t);
 void uicb_client_next(uicb_t);
 void uicb_client_prev(uicb_t);
+void uicb_client_prev_sel(uicb_t);
 void uicb_client_swap_next(uicb_t);
 void uicb_client_swap_prev(uicb_t);
 void uicb_client_focus_right(uicb_t cmd);


### PR DESCRIPTION
This commit adds a new command 'client_prev_sel'. It selects the previously selected client in the current tag.

I use client_prev_sel  in a tile_right layout with 4 terminals to quickly switch from the left master terminal to the last visited terminal on the right. Before wmfs I used tmux which has a similar command for this (last-pane).
