### PR TITLE
bug: tag_client and tag_set simultaneously

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -35,6 +35,7 @@ static const struct { char *name; void (*func)(Uicb cmd); } uicb_list[] =
      { "tag_next",             uicb_tag_next },
      { "tag_prev",             uicb_tag_prev },
      { "tag_client",           uicb_tag_client },
+     { "tag_client_and_set",   uicb_tag_client_and_set },
      { "tag_move_client_next", uicb_tag_move_client_next },
      { "tag_move_client_prev", uicb_tag_move_client_prev },
      { "tag_click",            uicb_tag_click },

--- a/src/tag.c
+++ b/src/tag.c
@@ -189,6 +189,13 @@ uicb_tag_client(Uicb cmd)
 }
 
 void
+uicb_tag_client_and_set(Uicb cmd)
+{
+    uicb_tag_client(cmd);
+    uicb_tag_set(cmd);
+}
+
+void
 uicb_tag_move_client_next(Uicb cmd)
 {
      (void)cmd;

--- a/src/tag.h
+++ b/src/tag.h
@@ -29,6 +29,7 @@ void uicb_tag_set_with_name(Uicb cmd);
 void uicb_tag_next(Uicb cmd);
 void uicb_tag_prev(Uicb cmd);
 void uicb_tag_client(Uicb cmd);
+void uicb_tag_client_and_set(Uicb cmd);
 void uicb_tag_move_client_next(Uicb cmd);
 void uicb_tag_move_client_prev(Uicb cmd);
 void uicb_tag_click(Uicb cmd);


### PR DESCRIPTION
if you have:

[key] mod = {"Mod4", "Shift"} key = "F2" func = "tag_client" cmd ="2" [/key]
[key] mod = {"Mod4", "Shift"} key = "F2" func = "tag_set" cmd ="2" [/key]

in your wmfsrc, the client is not directly visible or worse the client not move.
