### PR TITLE
Ajoute la possibilité de créer une règle "par défaut".

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -884,7 +884,7 @@ static void
 client_apply_rule(struct client *c)
 {
      struct rule *r;
-					struct rule *defaultr = NULL;
+     struct rule *defaultr = NULL;
      char *wmname = NULL;
      char *role = NULL;
      int f;


### PR DESCRIPTION
Cette règle est utilisée par les clients qui n'ont pas de règle spécifique.
Syntaxe :
[rule]
  instance = "*"
  # options
[/rule]
