### PR TITLE
Add circular option

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -192,6 +192,8 @@ config_tag(void)
      ks = fetch_section(sec, "tag");
      n = fetch_section_count(ks);
 
+     W->tag_circular = fetch_opt_first(sec, "1", "circular").boolean;
+
      /* [mouse] */
      if((mb = fetch_section(sec, "mouse")))
      {

--- a/src/parse_api.c
+++ b/src/parse_api.c
@@ -42,7 +42,7 @@ string_to_opt(char *s)
      ret.fnum = strtod(s, NULL);
 
      ret.boolean = (!strcmp(s, "true")
-                   || !strcmp(s, "true")
+                   || !strcmp(s, "True")
                    || !strcmp(s, "TRUE")
                    || !strcmp(s, "1"));
 

--- a/src/tag.c
+++ b/src/tag.c
@@ -169,8 +169,8 @@ uicb_tag_next(Uicb cmd)
      struct tag *t;
 
      if((t = TAILQ_NEXT(W->screen->seltag, next)))
-          tag_screen(W->screen, t);
-     else if( /* CIRCULAR OPTION */ 1)
+               tag_screen(W->screen, t);
+     else if(W->tag_circular)
           tag_screen(W->screen, TAILQ_FIRST(&W->screen->tags));
 }
 
@@ -182,7 +182,7 @@ uicb_tag_prev(Uicb cmd)
 
      if((t = TAILQ_PREV(W->screen->seltag, tsub, next)))
           tag_screen(W->screen, t);
-     else if( /* CIRCULAR OPTION */ 1)
+     else if(W->tag_circular)
           tag_screen(W->screen, TAILQ_LAST(&W->screen->tags, tsub));
 }
 
@@ -214,7 +214,7 @@ uicb_tag_move_client_next(Uicb cmd)
 
      if((t = TAILQ_NEXT(W->screen->seltag, next)))
           tag_client(t, W->client);
-     else if( /* CIRCULAR OPTION */ 1)
+     else if(W->tag_circular)
           tag_client(TAILQ_FIRST(&W->screen->tags), W->client);
 }
 
@@ -229,7 +229,7 @@ uicb_tag_move_client_prev(Uicb cmd)
 
      if((t = TAILQ_PREV(W->screen->seltag, tsub, next)))
           tag_client(t, W->client);
-     else if( /* CIRCULAR OPTION */ 1)
+     else if(W->tag_circular)
           tag_client(TAILQ_LAST(&W->screen->tags, tsub), W->client);
 }
 

--- a/src/wmfs.h
+++ b/src/wmfs.h
@@ -354,6 +354,8 @@ struct wmfs
 #define CFOCUS_CLICK 0x02
      Flags cfocus; /* Focus configuration, can be set to 0, CFOCUS_ENTER or CFOCUS_CLICK*/
 
+     bool tag_circular;
+
      /* Log file */
      FILE *log;
 

--- a/wmfsrc
+++ b/wmfsrc
@@ -91,6 +91,8 @@
 
 [tags]
 
+  circular = false
+
   # Use no screen option or screen = -1 to set tag on each screen
   [tag]
       screen = -1


### PR DESCRIPTION
When you do "ag_prev on the first tag, WMFS sends you to the last tag. In the same way, tag_next on the last tag sends you to the first tag.

This commit makes user able to add an option in the wmfsrc in order to turn off that feature.

```
[tags]
    circular = false

  # ...
[/tags]
```
