### PR TITLE
Fix manage of sticky windows (Closes #52)

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -972,14 +972,12 @@ client_new(Window w, XWindowAttributes *wa, bool scan)
           client_apply_rule(c);
      }
 
-     ewmh_manage_state_sticky(c);
-
      /*
       * Conf option set per client, for possibility
       * to config only one client
       */
      c->border = c->theme->client_border_width;
-     if(!(c->tbarw = c->theme->client_titlebar_width) || (c->flags & CLIENT_STICKY))
+     if(!(c->tbarw = c->theme->client_titlebar_width))
           c->tbarw = c->border;
 
      c->ncol = c->theme->client_n;

--- a/src/event.c
+++ b/src/event.c
@@ -245,7 +245,8 @@ event_maprequest(XEvent *e)
      /* Which windows to manage */
      if(!XGetWindowAttributes(EVDPY(e), ev->window, &at)
         || at.override_redirect
-        || ewmh_manage_window_type_desktop(ev->window))
+        || ewmh_manage_window_type_desktop(ev->window)
+        || ewmh_manage_state_sticky(ev->window))
           return;
 
      if(!client_gb_win(ev->window))

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -124,7 +124,7 @@ void ewmh_get_client_list(void);
 long ewmh_get_xembed_state(Window win);
 void ewmh_update_wmfs_props(void);
 void ewmh_manage_state(long data[], struct client *c);
-void ewmh_manage_state_sticky(struct client *c);
+bool ewmh_manage_state_sticky(Window win);
 void ewmh_manage_window_type(struct client *c);
 bool ewmh_manage_window_type_desktop(Window win);
 

--- a/src/layout.c
+++ b/src/layout.c
@@ -631,7 +631,7 @@ layout_client(struct client *c)
           return;
      }
 
-     if(c->flags & (CLIENT_FREE | CLIENT_STICKY))
+     if(c->flags & CLIENT_FREE)
      {
           layout_split_arrange_closed(c);
           c->flags ^= CLIENT_TILED;

--- a/src/wmfs.h
+++ b/src/wmfs.h
@@ -217,7 +217,6 @@ struct client
 #define CLIENT_TILED         0x2000
 #define CLIENT_MOUSE         0x4000
 #define CLIENT_IGNORE_TAG    0x8000
-#define CLIENT_STICKY        0x10000
      Flags flags;
      Window win, frame, tmp;
      SLIST_ENTRY(client) next;   /* Global list */


### PR DESCRIPTION
Don't manage sticky windows as client, just map them where they want to be mapped, and give them the focus.
