### PR TITLE
Fix XKeycodeToKeysym deprecated warning.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -27,7 +27,7 @@ SRCS=                 \
 # flags
 CFLAGS+= -DXDG_CONFIG_DIR=\"${XDG_CONFIG_DIR}\"
 CFLAGS+= -DWMFS_VERSION=\"${VERSION}\"
-CFLAGS+= -Wall -Wextra
+CFLAGS+= -Wall -Wextra -Werror
 
 OBJS= ${SRCS:.c=.o}
 

--- a/src/client.c
+++ b/src/client.c
@@ -304,7 +304,7 @@ client_swap(struct client *c, enum position p)
           if(ev.type == KeyPress)
           {
                XKeyPressedEvent *ke = &ev.xkey;
-               keysym = XKeycodeToKeysym(W->dpy, (KeyCode)ke->keycode, 0);
+               keysym = XkbKeycodeToKeysym(W->dpy, (KeyCode)ke->keycode, 0, 0);
 
                _REV_SBORDER();
 
@@ -1368,7 +1368,7 @@ client_fac_resize(struct client *c, enum position p, int fac)
           if(ev.type == KeyPress)
           {
                XKeyPressedEvent *ke = &ev.xkey;
-               keysym = XKeycodeToKeysym(W->dpy, (KeyCode)ke->keycode, 0);
+               keysym = XkbKeycodeToKeysym(W->dpy, (KeyCode)ke->keycode, 0, 0);
 
                _REV_BORDER();
 

--- a/src/event.c
+++ b/src/event.c
@@ -347,7 +347,7 @@ static void
 event_keypress(XEvent *e)
 {
      XKeyPressedEvent *ev = &e->xkey;
-     KeySym keysym = XKeycodeToKeysym(EVDPY(e), (KeyCode)ev->keycode, 0);
+     KeySym keysym = XkbKeycodeToKeysym(EVDPY(e), (KeyCode)ev->keycode, 0, 0);
      struct keybind *k;
 
      screen_update_sel();

--- a/src/layout.c
+++ b/src/layout.c
@@ -152,7 +152,7 @@ _historic_set(struct tag *t, bool prev)
           if(ev.type == KeyPress)
           {
                XKeyPressedEvent *ke = &ev.xkey;
-               keysym = XKeycodeToKeysym(W->dpy, (KeyCode)ke->keycode, 0);
+               keysym = XkbKeycodeToKeysym(W->dpy, (KeyCode)ke->keycode, 0, 0);
 
                _REV_BORDER();
 

--- a/src/wmfs.h
+++ b/src/wmfs.h
@@ -20,6 +20,7 @@
 /* Xlib */
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
+#include <X11/XKBlib.h>
 
 /* Local */
 #include "log.h"


### PR DESCRIPTION
This commit will fix warnings that are related to XKeycodeToKeysym.

Please see http://stackoverflow.com/questions/9838385/replace-of-xkeycodetokeysym
