### PR TITLE
Added an auto-maximum feature to graphs

### DIFF
--- a/src/status.c
+++ b/src/status.c
@@ -83,7 +83,7 @@ status_graph_draw(struct status_ctx *ctx, struct status_seq *sq, struct status_g
              j >= 0 && i >= sq->geo.x;
              --j, --i)
          {
-              if(j > max)
+              if(gc->datas[j] > max)
                   max = gc->datas[j];
          }
      }


### PR DESCRIPTION
Implementation of my own suggestion (see #67).
If maximum value is not correct, automatic maximum deducing will automatically be enabled.
