### PR TITLE
Fix builf on -fno-common toolchains

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -21,6 +21,9 @@
           if(!m->use_area || (m->use_area && INAREA(ev->x, ev->y, m->area))) \
                if(m->func)                                                   \
                     m->func(m->cmd);
+
+void (*event_handle[MAX_EV])(XEvent*);
+
 static void
 event_buttonpress(XEvent *e)
 {

--- a/src/event.h
+++ b/src/event.h
@@ -17,6 +17,6 @@
 
 void event_init(void);
 
-void (*event_handle[MAX_EV])(XEvent*);
+extern void (*event_handle[MAX_EV])(XEvent*);
 
 #endif /* EVENT_H */

--- a/src/wmfs.c
+++ b/src/wmfs.c
@@ -25,6 +25,8 @@
 #include "layout.h"
 #include "systray.h"
 
+struct wmfs *W;
+
 int
 wmfs_error_handler(Display *d, XErrorEvent *event)
 {

--- a/src/wmfs.h
+++ b/src/wmfs.h
@@ -444,6 +444,6 @@ void uicb_reload(Uicb cmd);
 void uicb_quit(Uicb cmd);
 
 /* Single global variable */
-struct wmfs *W;
+extern struct wmfs *W;
 
 #endif /* WMFS_H */


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: src/log.o:(.bss+0x0): multiple definition of `W'; src/barwin.o:(.bss+0x0): first defined here
    ld: src/wmfs.o:(.bss+0x0): multiple definition of `W'; src/barwin.o:(.bss+0x0): first defined here
    ld: src/wmfs.o:(.bss+0x10): multiple definition of `event_handle'; src/client.o:(.bss+0x10): first defined here

The change moves definitions into .c files.